### PR TITLE
Align buttons to bottom when the component is given a size

### DIFF
--- a/d2l-alignment-update.html
+++ b/d2l-alignment-update.html
@@ -111,7 +111,7 @@
 				flex: 0 0 auto;
 				padding: 4px;
 				align-items: center;
-				margin: 0rem 1rem 1rem 1rem;
+				margin: auto 1rem 1rem 1rem;
 			}
 
 			d2l-alert {


### PR DESCRIPTION
Sets the top margin of the buttons container to `auto`. When the component isn't given a height, it will be equivalent to a height of 0 like before, but if the component is given a height large enough to not require a scrollbar, the buttons will be placed at the bottom of the component instead of leaving empty whitespace there.