### PR TITLE
fix bug where alignment text overlaps the navbar in assignments

### DIFF
--- a/d2l-activity-alignments.html
+++ b/d2l-activity-alignments.html
@@ -23,6 +23,7 @@
 				display: flex;
 				flex-direction: column;
 				height: 100%;
+				z-index: 0;
 			}
 		</style>
 		<div class="d2l-activity-alignments-main">


### PR DESCRIPTION
@omsmith @awikkerink 
Any reason this would be bad?