### PR TITLE
DE32007 -- Render HTML in outcomes from ASN

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,8 @@
     "d2l-loading-spinner": "^6.0.3",
     "d2l-alert": "^3.1.0",
     "d2l-typography": "^6.1.3",
-    "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui#^1.0.11"
+    "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui#^1.0.11",
+    "s-html": "Brightspace/s-html#^1.2.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../d2l-polymer-siren-behaviors/siren-entity-loading.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="../s-html/s-html.html">
 
 <!--
 `d2l-select-outcomes`
@@ -46,7 +47,10 @@
 				<template is="dom-if" if="[[_hasOutcomeIdentifier(entity)]]">
 					<div class="d2l-outcome-identifier">[[_getOutcomeIdentifier(entity)]]</div>
 				</template>
-				<div class="d2l-outcome-text">[[entity.properties.description]]</div>
+				<div class="d2l-outcome-text">
+					<s-html hidden="[[!_fromTrustedSource(entity)]]" html="[[_getDescriptionHtml(entity)]]"></s-html>
+					<span hidden="[[_fromTrustedSource(entity)]]">[[entity.properties.description]]</span>
+				</div>
 			</div>
 
 			<d2l-loading-spinner slot="loading"></d2l-loading-spinner>
@@ -64,6 +68,44 @@
 
 			_hasOutcomeIdentifier: function(entity) {
 				return !!this._getOutcomeIdentifier(entity);
+			},
+
+			_fromTrustedSource: function(entity) {
+				return entity && entity.properties.source === 'asn';
+			},
+
+			_flattenList: function(innerHtml) {
+				var listItems = innerHtml.split(/<\s*li(?:\s+[^>]*)?>/i);
+				listItems.shift();
+				return listItems.map(function(listEntry) {
+					// remove closing tag if present
+					return listEntry.replace(/<\/\s*li(?:\s+[^>]*)?>/i, '');
+				}).join(', ');
+			},
+
+			_getDescriptionHtml: function(entity) {
+				if (!this._fromTrustedSource(entity)) {
+					return '';
+				}
+
+				// Handle ASN outcomes containing lists
+				var description = entity.properties.description || '';
+				var descriptionParts = description.split(/<\s*[uod]l(?:\s+[^>]*)?>/i);
+
+				var html = descriptionParts.shift();
+				html += descriptionParts.map(function(part) {
+					var listEndMatch = part.match(/<\/\s*[uod]l(?:\s+[^>]*)?>/i);
+					if (!listEndMatch) {
+						return this._flattenList(part);
+					}
+
+					var flattenedList = this._flattenList(part.substring(0, listEndMatch.index));
+					var suffix = part.substring(listEndMatch.index + listEndMatch[0].length);
+
+					return flattenedList + suffix;
+				}.bind(this)).join('');
+
+				return html;
 			},
 
 			_getOutcomeIdentifier: function(entity) {

--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -129,7 +129,6 @@
 				}
 
 				var parsedHtml = new DOMParser().parseFromString(entity.properties.description, 'text/html');
-				//TODO: handle parse error
 
 				this._processHtml(parsedHtml, parsedHtml.body);
 				return parsedHtml.body.innerHTML;

--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -83,15 +83,9 @@
 						continue;
 					}
 
-					if (child.textContent === child.innerHTML) {
-						flattenedList.appendChild(doc.createTextNode(child.textContent));
-					} else {
-						this._processHtml(doc, child);
-						var itemSpan = doc.createElement('span');
-						itemSpan.innerHTML = child.innerHTML;
-						flattenedList.appendChild(itemSpan);
+					while (child.firstChild) {
+						flattenedList.appendChild(child.firstChild);
 					}
-
 					flattenedList.appendChild(doc.createTextNode(', '));
 				}
 
@@ -100,37 +94,19 @@
 				return flattenedList;
 			},
 
-			_processHtml: function(doc, element) {
-				// Copy the children to an array first so that the list isn't mutated while being iterated upon
-				var children = [];
-				for (var i = 0; i < element.childNodes.length; i++) {
-					children.push(element.childNodes[i]);
-				}
-
-				children.forEach(function(child) {
-					if (!child.tagName) {
-						// text node
-						return;
-					}
-
-					if (/^[uod]l$/i.test(child.tagName)) {
-						// Flatten lists to plain text
-						var flattenedList = this._flattenList(doc, child);
-						element.replaceChild(flattenedList, child);
-					} else {
-						this._processHtml(doc, child);
-					}
-				}.bind(this));
-			},
-
 			_getDescriptionHtml: function(entity) {
 				if (!this._fromTrustedSource(entity) || !entity.properties.description) {
 					return '';
 				}
 
 				var parsedHtml = new DOMParser().parseFromString(entity.properties.description, 'text/html');
+				var listElements = parsedHtml.body.querySelectorAll('ul, ol, dl');
 
-				this._processHtml(parsedHtml, parsedHtml.body);
+				for (var i = 0; i < listElements.length; i++) {
+					var list = listElements[i];
+					list.parentElement.replaceChild(this._flattenList(parsedHtml, list), list);
+				}
+
 				return parsedHtml.body.innerHTML;
 			},
 

--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -41,6 +41,10 @@
 			d2l-loading-spinner {
 				--d2l-loading-spinner-size: 1.2rem;
 			}
+			
+			.d2l-outcome-wrap, .d2l-outcome-text {
+				width: 100%;
+			}
 		</style>
 		<siren-entity-loading href="[[href]]" token="[[token]]">
 			<div class="d2l-outcome-wrap">

--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -74,38 +74,65 @@
 				return entity && entity.properties.source === 'asn';
 			},
 
-			_flattenList: function(innerHtml) {
-				var listItems = innerHtml.split(/<\s*li(?:\s+[^>]*)?>/i);
-				listItems.shift();
-				return listItems.map(function(listEntry) {
-					// remove closing tag if present
-					return listEntry.replace(/<\/\s*li(?:\s+[^>]*)?>/i, '');
-				}).join(', ');
+			_flattenList: function(doc, listElement) {
+				var flattenedList = doc.createElement('span');
+				flattenedList.appendChild(doc.createTextNode(' '));
+				for (var i = 0; i < listElement.childNodes.length; i++) {
+					var child = listElement.childNodes[i];
+					if (!child.tagName || child.tagName.toLowerCase() !== 'li') {
+						continue;
+					}
+
+					if (child.textContent === child.innerHTML) {
+						flattenedList.appendChild(doc.createTextNode(child.textContent));
+					} else {
+						this._processHtml(doc, child);
+						var itemSpan = doc.createElement('span');
+						itemSpan.innerHTML = child.innerHTML;
+						flattenedList.appendChild(itemSpan);
+					}
+
+					flattenedList.appendChild(doc.createTextNode(', '));
+				}
+
+				flattenedList.replaceChild(doc.createTextNode(' '), flattenedList.lastChild);
+				flattenedList.normalize();
+				return flattenedList;
+			},
+
+			_processHtml: function(doc, element) {
+				// Copy the children to an array first so that the list isn't mutated while being iterated upon
+				var children = [];
+				for (var i = 0; i < element.childNodes.length; i++) {
+					children.push(element.childNodes[i]);
+				}
+
+				children.forEach(function(child) {
+					if (!child.tagName) {
+						// text node
+						return;
+					}
+
+					if (/^[uod]l$/i.test(child.tagName)) {
+						// Flatten lists to plain text
+						var flattenedList = this._flattenList(doc, child);
+						element.replaceChild(flattenedList, child);
+					} else {
+						this._processHtml(doc, child);
+					}
+				}.bind(this));
 			},
 
 			_getDescriptionHtml: function(entity) {
-				if (!this._fromTrustedSource(entity)) {
+				if (!this._fromTrustedSource(entity) || !entity.properties.description) {
 					return '';
 				}
 
-				// Handle ASN outcomes containing lists
-				var description = entity.properties.description || '';
-				var descriptionParts = description.split(/<\s*[uod]l(?:\s+[^>]*)?>/i);
+				var parsedHtml = new DOMParser().parseFromString(entity.properties.description, 'text/html');
+				//TODO: handle parse error
 
-				var html = descriptionParts.shift();
-				html += descriptionParts.map(function(part) {
-					var listEndMatch = part.match(/<\/\s*[uod]l(?:\s+[^>]*)?>/i);
-					if (!listEndMatch) {
-						return this._flattenList(part);
-					}
-
-					var flattenedList = this._flattenList(part.substring(0, listEndMatch.index));
-					var suffix = part.substring(listEndMatch.index + listEndMatch[0].length);
-
-					return flattenedList + suffix;
-				}.bind(this)).join('');
-
-				return html;
+				this._processHtml(parsedHtml, parsedHtml.body);
+				return parsedHtml.body.innerHTML;
 			},
 
 			_getOutcomeIdentifier: function(entity) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-select-outcomes",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "",
   "main": "index.html",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-select-outcomes",
-  "version": "0.0.5",
+  "version": "0.0.23",
   "description": "",
   "main": "index.html",
   "scripts": {

--- a/test/d2l-outcome.html
+++ b/test/d2l-outcome.html
@@ -21,6 +21,39 @@
 
     <script>
 		/* global suite, test, assert, fixture, setup, stubWhitelist */
+		var runTest = function(testName, href, testFunction) {
+			var element;
+			setup(function(done) {
+				element = fixture('basic');
+				function waitForLoad(entity, error) {
+					window.D2L.Siren.EntityStore.removeListener(
+						href,
+						'',
+						waitForLoad
+					);
+					if (error) {
+						done(error);
+						return;
+					}
+					setTimeout(function() {
+						done();
+					});
+				}
+				stubWhitelist();
+				window.D2L.Siren.EntityStore.addListener(
+					href,
+					'',
+					waitForLoad
+				);
+				element.href = href;
+				element.token = '';
+			});
+
+			test(testName, function(){
+				testFunction(element);
+			});
+		};
+
 		suite('d2l-outcome', function() {
 			test('instantiating the element works', function() {
 				var element = fixture('basic');
@@ -28,38 +61,47 @@
 			});
 
 			suite('smoke test', function() {
-				var element;
-				setup(function(done) {
-					element = fixture('basic');
-					var href = 'static-data/outcomes/c297b02c-19b1-485a-92db-e598316271c8/5f4d6901-7c10-4edc-b2e1-821efc5c3708.json';
-					function waitForLoad(entity, error) {
-						window.D2L.Siren.EntityStore.removeListener(
-							href,
-							'',
-							waitForLoad
-						);
-						if (error) {
-							done(error);
-							return;
-						}
-						setTimeout(function() {
-							done();
-						});
+				runTest(
+					'renders outcome',
+					'static-data/outcomes/c297b02c-19b1-485a-92db-e598316271c8/5f4d6901-7c10-4edc-b2e1-821efc5c3708.json',
+					function(element) {
+						var content = Polymer.dom(element.$$('siren-entity-loading')).textContent.trim();
+						assert.equal(content, 'Interpret words and phrases as they are used in a text, including determining technical, connotative, and figurative meanings, and analyze how specific word choices shape meaning or tone.');
 					}
-					stubWhitelist();
-					window.D2L.Siren.EntityStore.addListener(
-						href,
-						'',
-						waitForLoad
-					);
-					element.href = href;
-					element.token = '';
-				});
+				);
+			});
 
-				test('renders outcome', function() {
-					var content = Polymer.dom(element.$$('siren-entity-loading')).textContent.trim();
-					assert.equal(content, 'Interpret words and phrases as they are used in a text, including determining technical, connotative, and figurative meanings, and analyze how specific word choices shape meaning or tone.');
-				});
+			suite('asn basic list', function() {
+				runTest(
+					'flattens a single list in ASN outcomes',
+					'static-data/outcomes/asn-outcome-with-list.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-text s-html').html;
+						assert.equal('Prefix One, Two, Three Suffix', content);
+					}
+				);
+			});
+			
+			suite('asn multiple lists', function() {
+				runTest(
+					'flattens multiple lists in ASN outcomes',
+					'static-data/outcomes/asn-outcome-with-two-lists.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-text s-html').html;
+						assert.equal('A 1, 2, 3 B i, ii, iii C', content);
+					}
+				);
+			});
+			
+			suite('asn malformed list', function() {
+				runTest(
+					'flattens lists in ASN outcomes that are missing closing tags',
+					'static-data/outcomes/asn-outcome-with-malformed-list.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-text s-html').html;
+						assert.equal('Prefix One, Two, Three', content);
+					}
+				);
 			});
 		});
     </script>

--- a/test/d2l-outcome.html
+++ b/test/d2l-outcome.html
@@ -77,7 +77,7 @@
 					'static-data/outcomes/asn-outcome-with-list.json',
 					function(element) {
 						var content = element.$$('.d2l-outcome-text s-html').html;
-						assert.equal('Prefix One, Two, Three Suffix', content);
+						assert.equal('Prefix <span> One, Two, Three </span> Suffix', content);
 					}
 				);
 			});
@@ -88,7 +88,7 @@
 					'static-data/outcomes/asn-outcome-with-two-lists.json',
 					function(element) {
 						var content = element.$$('.d2l-outcome-text s-html').html;
-						assert.equal('A 1, 2, 3 B i, ii, iii C', content);
+						assert.equal('A <span> 1, 2, 3 </span> B <span> i, ii, iii </span> C', content);
 					}
 				);
 			});
@@ -99,7 +99,7 @@
 					'static-data/outcomes/asn-outcome-with-malformed-list.json',
 					function(element) {
 						var content = element.$$('.d2l-outcome-text s-html').html;
-						assert.equal('Prefix One, Two, Three', content);
+						assert.equal('Prefix <span> One, Two, Three </span>', content);
 					}
 				);
 			});

--- a/test/static-data/outcomes/asn-outcome-with-list.json
+++ b/test/static-data/outcomes/asn-outcome-with-list.json
@@ -2,7 +2,7 @@
 	"class": ["outcome"],
 	"properties": {
 		"notation": "",
-		"description": "Prefix <ul><li>One</li><li style=\"color: red;\">Two</li>< li >Three</ li ></ul> Suffix",
+		"description": "Prefix <ul><li>One</li><li style=\"color: red;\">Two</li><li >Three</li ></ul> Suffix",
 		"source": "asn"
 	},
 	"links": [

--- a/test/static-data/outcomes/asn-outcome-with-list.json
+++ b/test/static-data/outcomes/asn-outcome-with-list.json
@@ -1,0 +1,18 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"notation": "",
+		"description": "Prefix <ul><li>One</li><li style=\"color: red;\">Two</li>< li >Three</ li ></ul> Suffix",
+		"source": "asn"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/asn-outcome-with-list.json"
+		}
+	]
+}

--- a/test/static-data/outcomes/asn-outcome-with-malformed-list.json
+++ b/test/static-data/outcomes/asn-outcome-with-malformed-list.json
@@ -1,0 +1,18 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"notation": "",
+		"description": "Prefix <ul><li>One<li>Two<li>Three",
+		"source": "asn"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/asn-outcome-with-malformed-list.json"
+		}
+	]
+}

--- a/test/static-data/outcomes/asn-outcome-with-two-lists.json
+++ b/test/static-data/outcomes/asn-outcome-with-two-lists.json
@@ -1,0 +1,18 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"notation": "",
+		"description": "A <ul><li>1</li><li>2</li><li>3</li></ul> B <ul><li>i</li><li>ii</li><li>iii</li></ul> C",
+		"source": "asn"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/asn-outcome-with-two-lists.json"
+		}
+	]
+}


### PR DESCRIPTION
Renders HTML in outcomes from ASN, but replaces HTML lists with comma separated plain text (same as Lessons)

Requires this LMS change: https://git.dev.d2l/projects/CORE/repos/le/pull-requests/13025/overview