### PR TITLE
mpharoah/US102110_display-outcome-notation

### DIFF
--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -121,25 +121,29 @@
 
 				var properties = entity.properties;
 
-				var subject;
-				if (properties.subjects) {
-					if (properties.subjects.length > 0) {
-						subject = properties.subjects[0];
+				var notation = (properties.notation && properties.notation.trim()) || (properties.altNotation && properties.altNotation.trim());
+				var primarySubject = null;
+
+				if (properties.subjects && properties.subjects.length) {
+					for (var i = 0; i < properties.subjects.length; i++) {
+						if (properties.subjects[i] && properties.subjects[i].trim()) {
+							primarySubject = properties.subjects[i];
+							break;
+						}
 					}
 				}
 
-				return [
-					subject,
+				var outcomeInfo = [
+					primarySubject,
 					properties.label,
 					properties.listId
-				]
-					.map(function(piece) {
-						return piece && piece.trim();
-					})
-					.filter(function(piece) {
-						return piece;
-					})
-					.join(' ');
+				].filter(function(id) { return id; }).join(' ');
+
+				if (outcomeInfo) {
+					return notation ? (notation + ' - ' + outcomeInfo) : outcomeInfo;
+				}
+
+				return notation || '';
 			}
 		});
 	</script>

--- a/d2l-outcome.html
+++ b/d2l-outcome.html
@@ -135,8 +135,8 @@
 
 				var outcomeInfo = [
 					primarySubject,
-					properties.label,
-					properties.listId
+					properties.label && properties.label.trim(),
+					properties.listId && properties.listId.trim()
 				].filter(function(id) { return id; }).join(' ');
 
 				if (outcomeInfo) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-select-outcomes",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "",
   "main": "index.html",
   "scripts": {

--- a/test/d2l-outcome.html
+++ b/test/d2l-outcome.html
@@ -103,6 +103,51 @@
 					}
 				);
 			});
+			
+			suite('outcome with notation and label', function() {
+				runTest(
+					'shows the outcome notation, primary subject, label, and listId',
+					'static-data/outcomes/outcome-with-notation-and-subject.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-identifier').textContent;
+						assert.equal('notation - subject label listId', content);
+					}
+				);
+			});
+			
+			suite('outcome with altNotation but no notation', function() {
+				runTest(
+					'use altNotation if notation is null, empty, or only whitespace',
+					'static-data/outcomes/outcome-with-alt-notation-but-no-notation.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-identifier').textContent;
+						assert.equal('altNotation - subject', content);
+					}
+				);
+			});
+			
+			suite('outcome with notation only', function() {
+				runTest(
+					'correctly render outcome identifier for outcomes with a notation, but no subject, label, or listId',
+					'static-data/outcomes/outcome-with-notation-only.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-identifier').textContent;
+						assert.equal('notation', content);
+					}
+				);
+			});
+			
+			suite('outcome without notation', function() {
+				runTest(
+					'correctly render outcome identifier for outcomes with a subject, label, or listId, but no notation',
+					'static-data/outcomes/outcome-with-no-notation.json',
+					function(element) {
+						var content = element.$$('.d2l-outcome-identifier').textContent;
+						assert.equal('subject label', content);
+					}
+				);
+			});
+			
 		});
     </script>
   </body>

--- a/test/static-data/outcomes/outcome-with-alt-notation-but-no-notation.json
+++ b/test/static-data/outcomes/outcome-with-alt-notation-but-no-notation.json
@@ -1,0 +1,20 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"notation": "  ",
+		"altNotation": "altNotation",
+		"subjects": [ "subject" ],
+		"description": "Outcome description",
+		"source": "lores"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/outcome-with-alt-notation-but-no-notation.json"
+		}
+	]
+}

--- a/test/static-data/outcomes/outcome-with-no-notation.json
+++ b/test/static-data/outcomes/outcome-with-no-notation.json
@@ -1,0 +1,19 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"subjects": [ "subject" ],
+		"label": "label",
+		"description": "Outcome description",
+		"source": "lores"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/outcome-with-no-notation.json"
+		}
+	]
+}

--- a/test/static-data/outcomes/outcome-with-notation-and-subject.json
+++ b/test/static-data/outcomes/outcome-with-notation-and-subject.json
@@ -1,0 +1,27 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"notation": "notation",
+		"altNotation": "not this",
+		"label": "label",
+		"listId": "listId",
+		"subjects": [
+			null,
+			"    ",
+			"subject",
+			"not this"
+		],
+		"description": "Outcome description",
+		"source": "lores"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/outcome-with-notation-and-subject.json"
+		}
+	]
+}

--- a/test/static-data/outcomes/outcome-with-notation-only.json
+++ b/test/static-data/outcomes/outcome-with-notation-only.json
@@ -1,0 +1,18 @@
+{
+	"class": ["outcome"],
+	"properties": {
+		"notation": "notation",
+		"description": "Outcome description",
+		"source": "lores"
+	},
+	"links": [
+		{
+			"rel": ["about"],
+			"type": "text/html",
+			"href": "http://www.example.com"
+		}, {
+			"rel": ["self"],
+			"href": "static-data/outcomes/outcome-with-notation-only.json"
+		}
+	]
+}


### PR DESCRIPTION
https://rally1.rallydev.com/#/57732444928d/detail/userstory/269225774028?fdp=true

Show the outcome notation if it is present, separating it from the subject, label, and listId with a hyphen
![image](https://user-images.githubusercontent.com/12971370/49026679-76ff3980-f16c-11e8-92e7-2b016d44b604.png)
