### PR TITLE
DE33491 After removing a direct alignment from an activity, it reappears and is undeletable until refresh

### DIFF
--- a/d2l-alignment-list.js
+++ b/d2l-alignment-list.js
@@ -238,8 +238,10 @@ Polymer({
 	},
 
 	_onAlignmentRemove: function(e) {
-		var index = +e.target.dataset.index;
-		this.splice('_directAlignmentHrefs', index, 1);
+		const newMap = this._alignmentMap;
+		delete newMap[e.detail.entity.getLinkByRel("self").href];
+		this.set('_alignmentMap', {});
+		this.set('_alignmentMap', newMap);
 
 		// Notify screen readers that an alignment has been removed
 		var screenReaderAlert = this.create('d2l-offscreen');

--- a/d2l-alignment-list.js
+++ b/d2l-alignment-list.js
@@ -239,7 +239,7 @@ Polymer({
 
 	_onAlignmentRemove: function(e) {
 		const newMap = this._alignmentMap;
-		delete newMap[e.detail.entity.getLinkByRel("self").href];
+		delete newMap[e.detail.entity.getLinkByRel('self').href];
 		this.set('_alignmentMap', {});
 		this.set('_alignmentMap', newMap);
 


### PR DESCRIPTION
https://rally1.rallydev.com/#/57732444928d/detail/defect/295167224160?fdp=true
