### PR TITLE
testing auto tanslation

### DIFF
--- a/build/lang/ar.js
+++ b/build/lang/ar.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangArBehavior = {
 	ar: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'إضافة',
+          'addLabel': 'إضافة تحديد',
+          'alignmentRemoved': 'تمت إزالة المحاذاة',
+          'cancel': 'إلغاء',
+          'cancelLabel': 'إلغاء التحديد',
+          'directAlignments': 'تمت محاذاة {header-title} مباشرة مع هذا النشاط',
+          'error': 'حدث خطأ',
+          'indirectAlignments': 'تمت محاذاة {header-title} مع معايير آلية التقييم',
+          'removeAlignment': 'إزالة المحاذاة'
+}	
 };

--- a/build/lang/ar.js
+++ b/build/lang/ar.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangArBehavior = {
 	ar: {
-          'add': 'إضافة',
-          'addLabel': 'إضافة تحديد',
-          'alignmentRemoved': 'تمت إزالة المحاذاة',
-          'cancel': 'إلغاء',
-          'cancelLabel': 'إلغاء التحديد',
-          'directAlignments': 'تمت محاذاة {header-title} مباشرة مع هذا النشاط',
-          'error': 'حدث خطأ',
-          'indirectAlignments': 'تمت محاذاة {header-title} مع معايير آلية التقييم',
-          'removeAlignment': 'إزالة المحاذاة'
-}	
+		'add': 'إضافة',
+		'addLabel': 'إضافة تحديد',
+		'alignmentRemoved': 'تمت إزالة المحاذاة',
+		'cancel': 'إلغاء',
+		'cancelLabel': 'إلغاء التحديد',
+		'directAlignments': 'تمت محاذاة {header-title} مباشرة مع هذا النشاط',
+		'error': 'حدث خطأ',
+		'indirectAlignments': 'تمت محاذاة {header-title} مع معايير آلية التقييم',
+		'removeAlignment': 'إزالة المحاذاة'
+}
 };

--- a/build/lang/da.js
+++ b/build/lang/da.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangDaBehavior = {
 	da: {
-          'add': 'Tilføj',
-          'addLabel': 'Tilføj valg',
-          'alignmentRemoved': 'Justering fjernet',
-          'cancel': 'Annuller',
-          'cancelLabel': 'Annuller valg',
-          'directAlignments': '{header-title} justeret direkte til denne aktivitet',
-          'error': 'Der opstod en fejl',
-          'indirectAlignments': '{header-title} justeret til rubrikkriterier',
-          'removeAlignment': 'Fjern justering'
-}	
+		'add': 'Tilføj',
+		'addLabel': 'Tilføj valg',
+		'alignmentRemoved': 'Justering fjernet',
+		'cancel': 'Annuller',
+		'cancelLabel': 'Annuller valg',
+		'directAlignments': '{header-title} justeret direkte til denne aktivitet',
+		'error': 'Der opstod en fejl',
+		'indirectAlignments': '{header-title} justeret til rubrikkriterier',
+		'removeAlignment': 'Fjern justering'
+}
 };

--- a/build/lang/da.js
+++ b/build/lang/da.js
@@ -9,15 +9,15 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
 * @polymerBehavior D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangDaBehavior
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangDaBehavior = {
-	daDk: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+	da: {
+          'add': 'Tilføj',
+          'addLabel': 'Tilføj valg',
+          'alignmentRemoved': 'Justering fjernet',
+          'cancel': 'Annuller',
+          'cancelLabel': 'Annuller valg',
+          'directAlignments': '{header-title} justeret direkte til denne aktivitet',
+          'error': 'Der opstod en fejl',
+          'indirectAlignments': '{header-title} justeret til rubrikkriterier',
+          'removeAlignment': 'Fjern justering'
+}	
 };

--- a/build/lang/de.js
+++ b/build/lang/de.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangDeBehavior = {
 	de: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Hinzufügen',
+          'addLabel': 'Auswahl hinzufügen',
+          'alignmentRemoved': 'Ausrichtung entfernt',
+          'cancel': 'Abbrechen',
+          'cancelLabel': 'Auswahl aufheben',
+          'directAlignments': '{header-title} Direkt auf diese Aktivität ausgerichtet',
+          'error': 'Es ist ein Fehler aufgetreten.',
+          'indirectAlignments': '{header-title} Auf die Kriterien des Bewertungsschemas ausgerichtet',
+          'removeAlignment': 'Ausrichtung entfernen'
+}	
 };

--- a/build/lang/de.js
+++ b/build/lang/de.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangDeBehavior = {
 	de: {
-          'add': 'Hinzufügen',
-          'addLabel': 'Auswahl hinzufügen',
-          'alignmentRemoved': 'Ausrichtung entfernt',
-          'cancel': 'Abbrechen',
-          'cancelLabel': 'Auswahl aufheben',
-          'directAlignments': '{header-title} Direkt auf diese Aktivität ausgerichtet',
-          'error': 'Es ist ein Fehler aufgetreten.',
-          'indirectAlignments': '{header-title} Auf die Kriterien des Bewertungsschemas ausgerichtet',
-          'removeAlignment': 'Ausrichtung entfernen'
-}	
+		'add': 'Hinzufügen',
+		'addLabel': 'Auswahl hinzufügen',
+		'alignmentRemoved': 'Ausrichtung entfernt',
+		'cancel': 'Abbrechen',
+		'cancelLabel': 'Auswahl aufheben',
+		'directAlignments': '{header-title} Direkt auf diese Aktivität ausgerichtet',
+		'error': 'Es ist ein Fehler aufgetreten.',
+		'indirectAlignments': '{header-title} Auf die Kriterien des Bewertungsschemas ausgerichtet',
+		'removeAlignment': 'Ausrichtung entfernen'
+}
 };

--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangEnBehavior = {
 	en: {
-          'add': 'Add',
-          'addLabel': 'Add selection',
-          'cancel': 'Cancel',
-          'cancelLabel': 'Cancel selection',
-          'error': 'An error has occured',
-          'removeAlignment': 'Remove alignment',
-          'alignmentRemoved': 'Alignment removed',
-          'directAlignments': '{header-title} Aligned Directly to This Activity',
-          'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-}	
+		'add': 'Add',
+		'addLabel': 'Add selection',
+		'cancel': 'Cancel',
+		'cancelLabel': 'Cancel selection',
+		'error': 'An error has occured',
+		'removeAlignment': 'Remove alignment',
+		'alignmentRemoved': 'Alignment removed',
+		'directAlignments': '{header-title} Aligned Directly to This Activity',
+		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
+}
 };

--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangEnBehavior = {
 	en: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Add',
+          'addLabel': 'Add selection',
+          'cancel': 'Cancel',
+          'cancelLabel': 'Cancel selection',
+          'error': 'An error has occured',
+          'removeAlignment': 'Remove alignment',
+          'alignmentRemoved': 'Alignment removed',
+          'directAlignments': '{header-title} Aligned Directly to This Activity',
+          'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
+}	
 };

--- a/build/lang/es.js
+++ b/build/lang/es.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangEsBehavior = {
 	es: {
-          'add': 'Agregar',
-          'addLabel': 'Agregar selección',
-          'alignmentRemoved': 'Alineación eliminada',
-          'cancel': 'Cancelar',
-          'cancelLabel': 'Cancelar selección',
-          'directAlignments': '{header-title} alineado directamente con esta actividad',
-          'error': 'Se produjo un error',
-          'indirectAlignments': '{header-title} alineado según los criterios de la rúbrica',
-          'removeAlignment': 'Quitar la alineación'
-}	
+		'add': 'Agregar',
+		'addLabel': 'Agregar selección',
+		'alignmentRemoved': 'Alineación eliminada',
+		'cancel': 'Cancelar',
+		'cancelLabel': 'Cancelar selección',
+		'directAlignments': '{header-title} alineado directamente con esta actividad',
+		'error': 'Se produjo un error',
+		'indirectAlignments': '{header-title} alineado según los criterios de la rúbrica',
+		'removeAlignment': 'Quitar la alineación'
+}
 };

--- a/build/lang/es.js
+++ b/build/lang/es.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangEsBehavior = {
 	es: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Agregar',
+          'addLabel': 'Agregar selección',
+          'alignmentRemoved': 'Alineación eliminada',
+          'cancel': 'Cancelar',
+          'cancelLabel': 'Cancelar selección',
+          'directAlignments': '{header-title} alineado directamente con esta actividad',
+          'error': 'Se produjo un error',
+          'indirectAlignments': '{header-title} alineado según los criterios de la rúbrica',
+          'removeAlignment': 'Quitar la alineación'
+}	
 };

--- a/build/lang/fi.js
+++ b/build/lang/fi.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangFiBehavior = {
 	fi: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Add',
+          'addLabel': 'Add selection',
+          'cancel': 'Cancel',
+          'cancelLabel': 'Cancel selection',
+          'error': 'An error has occured',
+          'removeAlignment': 'Remove alignment',
+          'alignmentRemoved': 'Alignment removed',
+          'directAlignments': '{header-title} Aligned Directly to This Activity',
+          'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
+}	
 };

--- a/build/lang/fi.js
+++ b/build/lang/fi.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangFiBehavior = {
 	fi: {
-          'add': 'Add',
-          'addLabel': 'Add selection',
-          'cancel': 'Cancel',
-          'cancelLabel': 'Cancel selection',
-          'error': 'An error has occured',
-          'removeAlignment': 'Remove alignment',
-          'alignmentRemoved': 'Alignment removed',
-          'directAlignments': '{header-title} Aligned Directly to This Activity',
-          'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-}	
+		'add': 'Add',
+		'addLabel': 'Add selection',
+		'cancel': 'Cancel',
+		'cancelLabel': 'Cancel selection',
+		'error': 'An error has occured',
+		'removeAlignment': 'Remove alignment',
+		'alignmentRemoved': 'Alignment removed',
+		'directAlignments': '{header-title} Aligned Directly to This Activity',
+		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
+}
 };

--- a/build/lang/fr.js
+++ b/build/lang/fr.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangFrBehavior = {
 	fr: {
-		'add': 'Inclure',
-		'addLabel': 'Inclure la sélection',
-		'cancel': 'Annuler',
-		'cancelLabel': 'Annuler la sélection',
-		'error': 'Une erreur est survenue',
-		'removeAlignment': 'Supprimer l\'alignement',
-		'alignmentRemoved': 'L\'alignement a été supprimé',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Ajouter',
+          'addLabel': 'Ajouter la sélection',
+          'alignmentRemoved': 'Alignement supprimé',
+          'cancel': 'Annuler',
+          'cancelLabel': 'Annuler la sélection',
+          'directAlignments': '{header-title} aligné directement avec cette activité',
+          'error': 'Une erreur est survenue',
+          'indirectAlignments': '{header-title} aligné avec les critères de la rubrique',
+          'removeAlignment': 'Supprimer l’alignement'
+}	
 };

--- a/build/lang/fr.js
+++ b/build/lang/fr.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangFrBehavior = {
 	fr: {
-          'add': 'Ajouter',
-          'addLabel': 'Ajouter la sélection',
-          'alignmentRemoved': 'Alignement supprimé',
-          'cancel': 'Annuler',
-          'cancelLabel': 'Annuler la sélection',
-          'directAlignments': '{header-title} aligné directement avec cette activité',
-          'error': 'Une erreur est survenue',
-          'indirectAlignments': '{header-title} aligné avec les critères de la rubrique',
-          'removeAlignment': 'Supprimer l’alignement'
-}	
+		'add': 'Ajouter',
+		'addLabel': 'Ajouter la sélection',
+		'alignmentRemoved': 'Alignement supprimé',
+		'cancel': 'Annuler',
+		'cancelLabel': 'Annuler la sélection',
+		'directAlignments': '{header-title} aligné directement avec cette activité',
+		'error': 'Une erreur est survenue',
+		'indirectAlignments': '{header-title} aligné avec les critères de la rubrique',
+		'removeAlignment': 'Supprimer l’alignement'
+}
 };

--- a/build/lang/ja.js
+++ b/build/lang/ja.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangJaBehavior = {
 	ja: {
-          'add': '追加',
-          'addLabel': '選択の追加',
-          'alignmentRemoved': '整合性が削除されました',
-          'cancel': 'キャンセル',
-          'cancelLabel': '選択のキャンセル',
-          'directAlignments': '{header-title} このアクティビティに直接整合されました',
-          'error': 'エラーが発生しました',
-          'indirectAlignments': '{header-title} 注釈条件に整合されました',
-          'removeAlignment': '整合性を削除'
-}	
+		'add': '追加',
+		'addLabel': '選択の追加',
+		'alignmentRemoved': '整合性が削除されました',
+		'cancel': 'キャンセル',
+		'cancelLabel': '選択のキャンセル',
+		'directAlignments': '{header-title} このアクティビティに直接整合されました',
+		'error': 'エラーが発生しました',
+		'indirectAlignments': '{header-title} 注釈条件に整合されました',
+		'removeAlignment': '整合性を削除'
+}
 };

--- a/build/lang/ja.js
+++ b/build/lang/ja.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangJaBehavior = {
 	ja: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': '追加',
+          'addLabel': '選択の追加',
+          'alignmentRemoved': '整合性が削除されました',
+          'cancel': 'キャンセル',
+          'cancelLabel': '選択のキャンセル',
+          'directAlignments': '{header-title} このアクティビティに直接整合されました',
+          'error': 'エラーが発生しました',
+          'indirectAlignments': '{header-title} 注釈条件に整合されました',
+          'removeAlignment': '整合性を削除'
+}	
 };

--- a/build/lang/ko.js
+++ b/build/lang/ko.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangKoBehavior = {
 	ko: {
-          'add': '추가',
-          'addLabel': '선택 항목 추가',
-          'alignmentRemoved': '정렬이 제거됨',
-          'cancel': '취소',
-          'cancelLabel': '선택 항목 취소',
-          'directAlignments': '{header-title} 이 활동에 직접 정렬됨',
-          'error': '오류 발생',
-          'indirectAlignments': '{header-title} 루브릭 기준에 따라 정렬됨',
-          'removeAlignment': '정렬 제거'
-}	
+		'add': '추가',
+		'addLabel': '선택 항목 추가',
+		'alignmentRemoved': '정렬이 제거됨',
+		'cancel': '취소',
+		'cancelLabel': '선택 항목 취소',
+		'directAlignments': '{header-title} 이 활동에 직접 정렬됨',
+		'error': '오류 발생',
+		'indirectAlignments': '{header-title} 루브릭 기준에 따라 정렬됨',
+		'removeAlignment': '정렬 제거'
+}
 };

--- a/build/lang/ko.js
+++ b/build/lang/ko.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangKoBehavior = {
 	ko: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': '추가',
+          'addLabel': '선택 항목 추가',
+          'alignmentRemoved': '정렬이 제거됨',
+          'cancel': '취소',
+          'cancelLabel': '선택 항목 취소',
+          'directAlignments': '{header-title} 이 활동에 직접 정렬됨',
+          'error': '오류 발생',
+          'indirectAlignments': '{header-title} 루브릭 기준에 따라 정렬됨',
+          'removeAlignment': '정렬 제거'
+}	
 };

--- a/build/lang/nl.js
+++ b/build/lang/nl.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangNlBehavior = {
 	nl: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Toevoegen',
+          'addLabel': 'Selectie toevoegen',
+          'alignmentRemoved': 'Afstemming verwijderd',
+          'cancel': 'Annuleren',
+          'cancelLabel': 'Selectie annuleren',
+          'directAlignments': '{header-title} rechtstreeks afgestemd op deze activiteit',
+          'error': 'Er is een fout opgetreden',
+          'indirectAlignments': '{header-title} afgestemd op rubriccriteria',
+          'removeAlignment': 'Afstemming verwijderen'
+}	
 };

--- a/build/lang/nl.js
+++ b/build/lang/nl.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangNlBehavior = {
 	nl: {
-          'add': 'Toevoegen',
-          'addLabel': 'Selectie toevoegen',
-          'alignmentRemoved': 'Afstemming verwijderd',
-          'cancel': 'Annuleren',
-          'cancelLabel': 'Selectie annuleren',
-          'directAlignments': '{header-title} rechtstreeks afgestemd op deze activiteit',
-          'error': 'Er is een fout opgetreden',
-          'indirectAlignments': '{header-title} afgestemd op rubriccriteria',
-          'removeAlignment': 'Afstemming verwijderen'
-}	
+		'add': 'Toevoegen',
+		'addLabel': 'Selectie toevoegen',
+		'alignmentRemoved': 'Afstemming verwijderd',
+		'cancel': 'Annuleren',
+		'cancelLabel': 'Selectie annuleren',
+		'directAlignments': '{header-title} rechtstreeks afgestemd op deze activiteit',
+		'error': 'Er is een fout opgetreden',
+		'indirectAlignments': '{header-title} afgestemd op rubriccriteria',
+		'removeAlignment': 'Afstemming verwijderen'
+}
 };

--- a/build/lang/pt.js
+++ b/build/lang/pt.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangPtBehavior = {
 	pt: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Adicionar',
+          'addLabel': 'Adicionar seleção',
+          'alignmentRemoved': 'Alinhamento removido',
+          'cancel': 'Cancelar',
+          'cancelLabel': 'Cancelar seleção',
+          'directAlignments': '{header-title} alinhado diretamente a esta atividade',
+          'error': 'Ocorreu um erro',
+          'indirectAlignments': '{header-title} alinhado aos critérios de rubrica',
+          'removeAlignment': 'Remover alinhamento'
+}	
 };

--- a/build/lang/pt.js
+++ b/build/lang/pt.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangPtBehavior = {
 	pt: {
-          'add': 'Adicionar',
-          'addLabel': 'Adicionar seleção',
-          'alignmentRemoved': 'Alinhamento removido',
-          'cancel': 'Cancelar',
-          'cancelLabel': 'Cancelar seleção',
-          'directAlignments': '{header-title} alinhado diretamente a esta atividade',
-          'error': 'Ocorreu um erro',
-          'indirectAlignments': '{header-title} alinhado aos critérios de rubrica',
-          'removeAlignment': 'Remover alinhamento'
-}	
+		'add': 'Adicionar',
+		'addLabel': 'Adicionar seleção',
+		'alignmentRemoved': 'Alinhamento removido',
+		'cancel': 'Cancelar',
+		'cancelLabel': 'Cancelar seleção',
+		'directAlignments': '{header-title} alinhado diretamente a esta atividade',
+		'error': 'Ocorreu um erro',
+		'indirectAlignments': '{header-title} alinhado aos critérios de rubrica',
+		'removeAlignment': 'Remover alinhamento'
+}
 };

--- a/build/lang/sv.js
+++ b/build/lang/sv.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangSvBehavior = {
 	sv: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Lägg till',
+          'addLabel': 'Lägg till markering',
+          'alignmentRemoved': 'Justeringen har tagits bort',
+          'cancel': 'Avbryt',
+          'cancelLabel': 'Avbryt val',
+          'directAlignments': '{header-title} är direkt justerad efter den här aktiviteten',
+          'error': 'Ett fel har inträffat',
+          'indirectAlignments': '{header-title} är justerad efter rubriceringskriterier',
+          'removeAlignment': 'Ta bort justering'
+}	
 };

--- a/build/lang/sv.js
+++ b/build/lang/sv.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangSvBehavior = {
 	sv: {
-          'add': 'Lägg till',
-          'addLabel': 'Lägg till markering',
-          'alignmentRemoved': 'Justeringen har tagits bort',
-          'cancel': 'Avbryt',
-          'cancelLabel': 'Avbryt val',
-          'directAlignments': '{header-title} är direkt justerad efter den här aktiviteten',
-          'error': 'Ett fel har inträffat',
-          'indirectAlignments': '{header-title} är justerad efter rubriceringskriterier',
-          'removeAlignment': 'Ta bort justering'
-}	
+		'add': 'Lägg till',
+		'addLabel': 'Lägg till markering',
+		'alignmentRemoved': 'Justeringen har tagits bort',
+		'cancel': 'Avbryt',
+		'cancelLabel': 'Avbryt val',
+		'directAlignments': '{header-title} är direkt justerad efter den här aktiviteten',
+		'error': 'Ett fel har inträffat',
+		'indirectAlignments': '{header-title} är justerad efter rubriceringskriterier',
+		'removeAlignment': 'Ta bort justering'
+}
 };

--- a/build/lang/tr.js
+++ b/build/lang/tr.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangTrBehavior = {
 	tr: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': 'Ekle',
+          'addLabel': 'Seçimi ekle',
+          'alignmentRemoved': 'Hizalama kaldırıldı',
+          'cancel': 'İptal',
+          'cancelLabel': 'Seçimi iptal et',
+          'directAlignments': '{header-title} Doğrudan Bu Etkinliğe Hizalandı',
+          'error': 'Bir hata oluştu',
+          'indirectAlignments': '{header-title} Rubrik Kriterlerine Hizalandı',
+          'removeAlignment': 'Hizalamayı kaldır'
+}	
 };

--- a/build/lang/tr.js
+++ b/build/lang/tr.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangTrBehavior = {
 	tr: {
-          'add': 'Ekle',
-          'addLabel': 'Seçimi ekle',
-          'alignmentRemoved': 'Hizalama kaldırıldı',
-          'cancel': 'İptal',
-          'cancelLabel': 'Seçimi iptal et',
-          'directAlignments': '{header-title} Doğrudan Bu Etkinliğe Hizalandı',
-          'error': 'Bir hata oluştu',
-          'indirectAlignments': '{header-title} Rubrik Kriterlerine Hizalandı',
-          'removeAlignment': 'Hizalamayı kaldır'
-}	
+		'add': 'Ekle',
+		'addLabel': 'Seçimi ekle',
+		'alignmentRemoved': 'Hizalama kaldırıldı',
+		'cancel': 'İptal',
+		'cancelLabel': 'Seçimi iptal et',
+		'directAlignments': '{header-title} Doğrudan Bu Etkinliğe Hizalandı',
+		'error': 'Bir hata oluştu',
+		'indirectAlignments': '{header-title} Rubrik Kriterlerine Hizalandı',
+		'removeAlignment': 'Hizalamayı kaldır'
+}
 };

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -9,7 +9,7 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
 * @polymerBehavior D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhTwBehavior
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhTwBehavior = {
-	zhtw: {
+	zhTw: {
 		'add': '新增',
 		'addLabel': '新增選擇項目',
 		'alignmentRemoved': '校準已移除',

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -5,19 +5,19 @@ window.D2L.PolymerBehaviors.SelectOutcomes = window.D2L.PolymerBehaviors.SelectO
 window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior || {};
 
 /*
-* Zh Tw lang terms
+* ZhTw lang terms
 * @polymerBehavior D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhTwBehavior
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhTwBehavior = {
-	zhTw: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+	zhtw: {
+          'add': '新增',
+          'addLabel': '新增選擇項目',
+          'alignmentRemoved': '校準已移除',
+          'cancel': '取消',
+          'cancelLabel': '取消選擇項目',
+          'directAlignments': '{header-title} 直接配合此活動校準',
+          'error': '發生錯誤',
+          'indirectAlignments': '{header-title} 配合量規標準校準',
+          'removeAlignment': '移除校準'
+}	
 };

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhTwBehavior = {
 	zhtw: {
-          'add': '新增',
-          'addLabel': '新增選擇項目',
-          'alignmentRemoved': '校準已移除',
-          'cancel': '取消',
-          'cancelLabel': '取消選擇項目',
-          'directAlignments': '{header-title} 直接配合此活動校準',
-          'error': '發生錯誤',
-          'indirectAlignments': '{header-title} 配合量規標準校準',
-          'removeAlignment': '移除校準'
-}	
+		'add': '新增',
+		'addLabel': '新增選擇項目',
+		'alignmentRemoved': '校準已移除',
+		'cancel': '取消',
+		'cancelLabel': '取消選擇項目',
+		'directAlignments': '{header-title} 直接配合此活動校準',
+		'error': '發生錯誤',
+		'indirectAlignments': '{header-title} 配合量規標準校準',
+		'removeAlignment': '移除校準'
+}
 };

--- a/build/lang/zh.js
+++ b/build/lang/zh.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhBehavior = {
 	zh: {
-          'add': '添加',
-          'addLabel': 'Add selection',
-          'alignmentRemoved': 'Alignment removed',
-          'cancel': '取消',
-          'cancelLabel': 'Cancel selection',
-          'directAlignments': '{header-title} Aligned Directly to This Activity',
-          'error': '已经出现错误。',
-          'indirectAlignments': '{header-title} Aligned to Rubric Criteria',
-          'removeAlignment': 'Remove alignment'
-}	
+		'add': '添加',
+		'addLabel': 'Add selection',
+		'alignmentRemoved': 'Alignment removed',
+		'cancel': '取消',
+		'cancelLabel': 'Cancel selection',
+		'directAlignments': '{header-title} Aligned Directly to This Activity',
+		'error': '已经出现错误。',
+		'indirectAlignments': '{header-title} Aligned to Rubric Criteria',
+		'removeAlignment': 'Remove alignment'
+}
 };

--- a/build/lang/zh.js
+++ b/build/lang/zh.js
@@ -10,14 +10,14 @@ window.D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior = window.D2L.Polymer
  */
 D2L.PolymerBehaviors.SelectOutcomes.LocalizeBehavior.LangZhBehavior = {
 	zh: {
-		'add': 'Add',
-		'addLabel': 'Add selection',
-		'cancel': 'Cancel',
-		'cancelLabel': 'Cancel selection',
-		'error': 'An error has occured',
-		'removeAlignment': 'Remove alignment',
-		'alignmentRemoved': 'Alignment removed',
-		'directAlignments': '{header-title} Aligned Directly to This Activity',
-		'indirectAlignments': '{header-title} Aligned to Rubric Criteria'
-	}
+          'add': '添加',
+          'addLabel': 'Add selection',
+          'alignmentRemoved': 'Alignment removed',
+          'cancel': '取消',
+          'cancelLabel': 'Cancel selection',
+          'directAlignments': '{header-title} Aligned Directly to This Activity',
+          'error': '已经出现错误。',
+          'indirectAlignments': '{header-title} Aligned to Rubric Criteria',
+          'removeAlignment': 'Remove alignment'
+}	
 };

--- a/copy-langterms-to-js-files.js
+++ b/copy-langterms-to-js-files.js
@@ -24,10 +24,11 @@ var langMap = {
 
 // loop through all json files
 buildFiles.forEach(function(filename, index) {
+	// get lang name from file
 	this[index] = filename.substring(0, filename.length-3)
 	try {
-		var lang_json = fs.readFileSync(`lang/${this[index]}.json`, 'utf8');
-		writeJSLangFile(langMap[this[index]], lang_json, filename);
+		var langJSON = fs.readFileSync(`lang/${this[index]}.json`, 'utf8');
+		writeJSLangFile(langMap[this[index]], langJSON, filename);
 
 	}
 	catch (err) {
@@ -35,9 +36,11 @@ buildFiles.forEach(function(filename, index) {
 	}
 }, buildFiles);
 
-
-function writeJSLangFile(lang, lang_json, filename) {
-	langName = lang.charAt(0).toLowerCase() + lang.substring(1, lang.length);
+// hardcoded strings since all files follow the same format
+// replacing double quotes with single quotes and using double tabs for spacing issues
+// TODO: Fix 2nd last bracket spacing
+function writeJSLangFile(lang, langJSON, filename) {
+	var langName = lang.charAt(0).toLowerCase() + lang.substring(1, lang.length);
 	var contents = `import '@polymer/polymer/polymer-legacy.js';
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
@@ -49,10 +52,9 @@ window.D2L.PolymerBehaviors.${app}.LocalizeBehavior = window.D2L.PolymerBehavior
 * @polymerBehavior D2L.PolymerBehaviors.${app}.LocalizeBehavior.Lang${lang}Behavior
  */
 D2L.PolymerBehaviors.${app}.LocalizeBehavior.Lang${lang}Behavior = {
-	${langName}: ${JSON.stringify(JSON.parse(lang_json), null, "\t\t").replace(/"/g, '\'')}
+	${langName}: ${JSON.stringify(JSON.parse(langJSON), null, "\t\t").replace(/"/g, '\'')}
 };
 `;
-	console.log(contents.length);
 	fs.writeFile(buildLangFolder + filename, contents, function (err) {
 		if (err) {
 			console.log(err);

--- a/copy-langterms-to-js-files.js
+++ b/copy-langterms-to-js-files.js
@@ -1,11 +1,10 @@
 var fs = require('fs');
 var buildLangFolder = 'build/lang/';
-var langFolder = 'lang/';
 var buildFiles = fs.readdirSync(buildLangFolder);
 var app = 'SelectOutcomes'
 
 // Mapping form json names to behavior lang names
-langMap = {
+var langMap = {
 	'ar': 'Ar',
 	'da': 'Da',
 	'de': 'De',
@@ -38,6 +37,7 @@ buildFiles.forEach(function(filename, index) {
 
 
 function writeJSLangFile(lang, lang_json, filename) {
+	langName = lang.charAt(0).toLowerCase() + lang.substring(1, lang.length);
 	var contents = `import '@polymer/polymer/polymer-legacy.js';
 window.D2L = window.D2L || {};
 window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
@@ -49,10 +49,11 @@ window.D2L.PolymerBehaviors.${app}.LocalizeBehavior = window.D2L.PolymerBehavior
 * @polymerBehavior D2L.PolymerBehaviors.${app}.LocalizeBehavior.Lang${lang}Behavior
  */
 D2L.PolymerBehaviors.${app}.LocalizeBehavior.Lang${lang}Behavior = {
-	${lang.toLowerCase()}: ${JSON.stringify(JSON.parse(lang_json), null, "\t\t").replace(/"/g, '\'')}
+	${langName}: ${JSON.stringify(JSON.parse(lang_json), null, "\t\t").replace(/"/g, '\'')}
 };
 `;
-	fs.writeFile(buildLangFolder+filename, contents, function (err) {
+	console.log(contents.length);
+	fs.writeFile(buildLangFolder + filename, contents, function (err) {
 		if (err) {
 			console.log(err);
 		}

--- a/copy-langterms-to-js-files.js
+++ b/copy-langterms-to-js-files.js
@@ -1,0 +1,60 @@
+var fs = require('fs');
+var buildLangFolder = 'build/lang/';
+var langFolder = 'lang/';
+var buildFiles = fs.readdirSync(buildLangFolder);
+var app = 'SelectOutcomes'
+
+// Mapping form json names to behavior lang names
+langMap = {
+	'ar': 'Ar',
+	'da': 'Da',
+	'de': 'De',
+	'en': 'En',
+	'es': 'Es',
+	'fi': 'Fi',
+	'fr': 'Fr',
+	'ja': 'Ja',
+	'ko': 'Ko',
+	'nl': 'Nl',
+	'pt': 'Pt',
+	'sv': 'Sv',
+	'tr': 'Tr',
+	'zh': 'Zh',
+	'zh-tw': 'ZhTw'
+};
+
+// loop through all json files
+buildFiles.forEach(function(filename, index) {
+	this[index] = filename.substring(0, filename.length-3)
+	try {
+		var lang_json = fs.readFileSync(`lang/${this[index]}.json`, 'utf8');
+		writeJSLangFile(langMap[this[index]], lang_json, filename);
+
+	}
+	catch (err) {
+		console.log(err);
+	}
+}, buildFiles);
+
+
+function writeJSLangFile(lang, lang_json, filename) {
+	var contents = `import '@polymer/polymer/polymer-legacy.js';
+window.D2L = window.D2L || {};
+window.D2L.PolymerBehaviors = window.D2L.PolymerBehaviors || {};
+window.D2L.PolymerBehaviors.${app} = window.D2L.PolymerBehaviors.${app} || {};
+window.D2L.PolymerBehaviors.${app}.LocalizeBehavior = window.D2L.PolymerBehaviors.${app}.LocalizeBehavior || {};
+
+/*
+* ${lang} lang terms
+* @polymerBehavior D2L.PolymerBehaviors.${app}.LocalizeBehavior.Lang${lang}Behavior
+ */
+D2L.PolymerBehaviors.${app}.LocalizeBehavior.Lang${lang}Behavior = {
+	${lang.toLowerCase()}: ${JSON.stringify(JSON.parse(lang_json), null, "\t\t").replace(/"/g, '\'')}
+};
+`;
+	fs.writeFile(buildLangFolder+filename, contents, function (err) {
+		if (err) {
+			console.log(err);
+		}
+	});
+}

--- a/copy-langterms-to-js-files.js
+++ b/copy-langterms-to-js-files.js
@@ -22,7 +22,7 @@ var langMap = {
 	'zh-tw': 'ZhTw'
 };
 
-// loop through all json files
+// loop through all js files
 buildFiles.forEach(function(filename, index) {
 	// get lang name from file
 	this[index] = filename.substring(0, filename.length-3)


### PR DESCRIPTION
Work in progress script to copy new translations from the json file to js. The script is `copy-langterms-to-js-files.js`. Haven't had time to refine it.
This should work for any web component that has automated serge translations similar to this e.g. outcomes loa WC, just need to change the `app` variable for each WC.
The only fix left for the `.js` file is the spacing for the 2nd closing bracket.