### PR TITLE
Fix show-select-outcomes slot appearing beside alignment list

### DIFF
--- a/d2l-user-alignment-list.js
+++ b/d2l-user-alignment-list.js
@@ -36,7 +36,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-user-alignment-list
 				/* The standard button box-shadow width */
 				--d2l-alignment-list-overflow-margin: 4px;
 			}
-			
+
 			.d2l-alignment-list-content {
 				display: flex;
 				flex-direction: column;
@@ -129,13 +129,13 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-user-alignment-list
 				<template is="dom-if" if="[[_promiseError]]">
 					<d2l-alert type="error">[[localize('error')]]</d2l-alert>
 				</template>
+				<template is="dom-if" if="[[_isEditable(entity, readOnly)]]">
+					<div>
+						<slot name="show-select-outcomes"></slot>
+					</div>
+				</template>
 			</div>
 			<d2l-loading-spinner slot="loading"></d2l-loading-spinner>
-			<template is="dom-if" if="[[_isEditable(entity, readOnly)]]">
-				<div>
-					<slot name="show-select-outcomes"></slot>
-				</div>
-			</template>
 		</siren-entity-loading>
 	</template>
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -26,6 +26,7 @@
 		See: https://github.com/Polymer/polymer-modulizer/issues/154
 		-->
 	<script type="module">
+window.D2L.Siren.WhitelistBehavior._testMode(true);
 const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>

--- a/test/a11y.html
+++ b/test/a11y.html
@@ -26,6 +26,7 @@ import '../d2l-select-outcomes.js';
 suite('d2l-select-outcomes', function() {
 	suite('a11y', function() {
 		setup(function(done) {
+			window.D2L.Siren.WhitelistBehavior._testMode(true);
 			function stubFetch(href, entity) {
 				window.d2lfetch.fetch
 					.withArgs(href)
@@ -211,6 +212,10 @@ suite('d2l-select-outcomes', function() {
 			window.D2L.Siren.EntityStore.addListener('https://15215d45-f7e9-4967-bf9b-13a685538829.outcomes.api.dev.brightspace.com/outcomes/73292f97-ebe5-43d5-b1df-299d98f1e0c4/84f0b418-2f25-4184-87e5-9ab7f86fbc34', '', waitForFetch);
 			fixtureElement.href = 'https://15215d45-f7e9-4967-bf9b-13a685538829.activities.api.dev.brightspace.com/activities/6606_3000_1/usages/6609';
 			fixtureElement.token = '';
+		});
+
+		teardown(function() {
+			window.D2L.Siren.WhitelistBehavior._testMode(false);
 		});
 
 		test('A11y Audit - Fixture: d2l-select-outcomes', function() {

--- a/test/d2l-activity-alignment-tags.html
+++ b/test/d2l-activity-alignment-tags.html
@@ -27,6 +27,7 @@ suite('d2l-alignment', function() {
 	suite('smoke test', function() {
 		var element;
 		setup(function(done) {
+			window.D2L.Siren.WhitelistBehavior._testMode(true);
 			element = fixture('basic');
 			var href = 'static-data/activity-usages/c297b02c-19b1-485a-92db-e598316271c8/f2b85092-5fbf-4e19-8345-8971f79debd8.json';
 			function waitForLoad(entity, error) {
@@ -51,6 +52,10 @@ suite('d2l-alignment', function() {
 			);
 			element.href = 'static-data/activity-usages/c297b02c-19b1-485a-92db-e598316271c8/f2b85092-5fbf-4e19-8345-8971f79debd8.json';
 			element.token = '';
+		});
+
+		teardown(function() {
+			window.D2L.Siren.WhitelistBehavior._testMode(false);
 		});
 
 		test('verify outcome tags', function(done) {

--- a/test/d2l-alignment-intent.html
+++ b/test/d2l-alignment-intent.html
@@ -31,6 +31,7 @@ suite('d2l-alignment-intent', function() {
 	suite('smoke test', function() {
 		var element;
 		setup(function(done) {
+			window.D2L.Siren.WhitelistBehavior._testMode(true);
 			element = fixture('basic');
 			var href = 'static-data/intents/c297b02c-19b1-485a-92db-e598316271c8/5f4d6901-7c10-4edc-b2e1-821efc5c3708.json';
 			function waitForLoad(entity, error) {
@@ -55,6 +56,10 @@ suite('d2l-alignment-intent', function() {
 			);
 			element.href = 'static-data/intents/c297b02c-19b1-485a-92db-e598316271c8/5f4d6901-7c10-4edc-b2e1-821efc5c3708.json';
 			element.token = '';
+		});
+
+		teardown(function() {
+			window.D2L.Siren.WhitelistBehavior._testMode(false);
 		});
 
 		test('sets d2l-outcome href', function() {

--- a/test/d2l-alignment.html
+++ b/test/d2l-alignment.html
@@ -31,6 +31,7 @@ suite('d2l-alignment', function() {
 	suite('smoke test', function() {
 		var element;
 		setup(function(done) {
+			window.D2L.Siren.WhitelistBehavior._testMode(true);
 			element = fixture('basic');
 			var href = 'static-data/outcomes/c297b02c-19b1-485a-92db-e598316271c8/5f4d6901-7c10-4edc-b2e1-821efc5c3708.json';
 			function waitForLoad(entity, error) {
@@ -55,6 +56,10 @@ suite('d2l-alignment', function() {
 			);
 			element.href = 'static-data/alignments/c297b02c-19b1-485a-92db-e598316271c8/5f4d6901-7c10-4edc-b2e1-821efc5c3708.json';
 			element.token = '';
+		});
+
+		teardown(function() {
+			window.D2L.Siren.WhitelistBehavior._testMode(false);
 		});
 
 		test('sets d2l-outcome href', function() {

--- a/test/d2l-outcome.html
+++ b/test/d2l-outcome.html
@@ -54,6 +54,7 @@ D2L.PolymerBehaviors.FetchSirenEntityBehavior._makeRequest = function(request) {
 			return Promise.resolve(SirenParse(input_data));
 	}
 };
+window.D2L.Siren.WhitelistBehavior._testMode(true);
 
 /* global suite, test, assert, fixture */
 suite('d2l-outcome', function() {


### PR DESCRIPTION
Issue:
![image](https://user-images.githubusercontent.com/7862298/60904511-2d69e780-a241-11e9-9244-ff65e544a429.png)

I put the show-select-outcomes slow in the content div instead of its own place in the default d2l-entity-loading slot
