### PR TITLE
Add support for indeterminate checkbox UI state

### DIFF
--- a/d2l-alignment-update.js
+++ b/d2l-alignment-update.js
@@ -134,7 +134,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-alignment-update">
 				<ul role="listbox" aria-multiselectable="true" aria-busy="[[_loading]]" tabindex="0" on-focus="_handleListFocus">
 					<template is="dom-repeat" items="[[candidateEntities]]">
 						<li class$="[[_getClass(index, candidateEntities)]]" tabindex="-1" role="option" aria-selected$="[[_getAriaChecked(item)]]" aria-checked$="[[_getAriaChecked(item)]]" aria-labelledby="[[id]]alignment-intent-[[index]]" on-keydown="_onKeyDown" on-focus="_handleOptionFocus" on-blur="_handleOptionBlur">
-							<d2l-input-checkbox tabindex="-1"  not-tabbable="true" checked="[[_getChecked(item)]]" on-change="_onOutcomeSelectChange"  data-index$="[[index]]" >
+							<d2l-input-checkbox tabindex="-1"  not-tabbable="true" checked="[[_getChecked(item)]]" indeterminate="[[_getIndeterminate(item)]]" on-change="_onOutcomeSelectChange"  data-index$="[[index]]" >
 								<d2l-alignment-intent id$="[[id]]alignment-intent-[[index]]" href="[[_getIntent(item)]]" token="[[token]]"></d2l-alignment-intent>
 							</d2l-input-checkbox>
 						</li>
@@ -357,6 +357,10 @@ Polymer({
 
 	_getChecked: function(candidate) {
 		return candidate.hasClass(Classes.alignments.selected);
+	},
+
+	_getIndeterminate: function(candidate) {
+		return candidate.hasClass(Classes.alignments.indeterminate);
 	},
 
 	_getAriaChecked: function(candidate) {

--- a/demo/request-mock.js
+++ b/demo/request-mock.js
@@ -313,7 +313,8 @@ D2L.PolymerBehaviors.FetchSirenEntityBehavior._makeRequest = function(request) {
 					'entities': [
 						{
 							'class': [
-								'alignment-candidate'
+								'alignment-candidate',
+								'selected'
 							],
 							'rel': [
 								'item'
@@ -329,7 +330,8 @@ D2L.PolymerBehaviors.FetchSirenEntityBehavior._makeRequest = function(request) {
 							]
 						}, {
 							'class': [
-								'alignment-candidate'
+								'alignment-candidate',
+								'indeterminate'
 							],
 							'rel': [
 								'item'


### PR DESCRIPTION
The `indeterminate` attribute on the `d2l-input-checkbox` is existing functionality (see https://github.com/BrightspaceUI/core/tree/master/components/inputs#checkboxes).