### PR TITLE
using labs version of multi-select

### DIFF
--- a/d2l-activity-alignment-tag-list.js
+++ b/d2l-activity-alignment-tag-list.js
@@ -3,9 +3,8 @@ import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import 'd2l-polymer-siren-behaviors/store/entity-behavior.js';
 import 'd2l-polymer-siren-behaviors/store/siren-action-behavior.js';
 import OutcomeParserBehavior from './d2l-outcome-parser-behavior.js';
-import 'd2l-multi-select/localize-behavior.js';
-import 'd2l-multi-select/d2l-multi-select-list-item.js';
-import 'd2l-multi-select/d2l-multi-select-list.js';
+import '@brightspace-ui-labs/multi-select/multi-select-list-item.js';
+import '@brightspace-ui-labs/multi-select/multi-select-list.js';
 import 'd2l-hypermedia-constants/d2l-hypermedia-constants.js';
 import 'd2l-button/d2l-button-icon.js';
 import 'd2l-tooltip/d2l-tooltip.js';
@@ -53,16 +52,16 @@ class ActivityAlignmentTagList extends mixinBehaviors([
 
 	static get template() {
 		return html`
-			<d2l-multi-select-list>
+			<d2l-labs-multi-select-list>
 				<template is="dom-repeat" items="[[_getAlignmentToOutcomeMap(_alignmentHrefs,_alignmentMap,_intentMap,_outcomeMap)]]">
-					<d2l-multi-select-list-item
+					<d2l-labs-multi-select-list-item
 						text="[[_getOutcomeTextDescription(item)]]"
 						short-text="[[_getOutcomeShortDescription(item)]]"
 						max-chars="40"
 						deletable="[[_canDelete(item,readOnly)]]"
-						on-d2l-multi-select-list-item-deleted="_removeOutcome"
+						on-d2l-labs-multi-select-list-item-deleted="_removeOutcome"
 						style="margin-top: 3px;"
-					></d2l-multi-select-list-item>
+					></d2l-labs-multi-select-list-item>
 				</template>
 				<template is="dom-if" if="[[_canUpdate(entity,readOnly)]]">
 					<d2l-button-icon
@@ -74,7 +73,7 @@ class ActivityAlignmentTagList extends mixinBehaviors([
 					></d2l-button-icon>
 					<d2l-tooltip for="browse-outcome-button" position="top">[[browseOutcomesText]]</d2l-tooltip>
 				</template>
-			</d2l-multi-select-list>
+			</d2l-labs-multi-select-list>
 			<div style="display: none;">
 				<template is="dom-repeat" items="[[_alignmentHrefs]]">
 					<d2l-siren-map-helper href="[[item]]" token="[[token]]" map="{{_alignmentMap}}"></d2l-siren-map-helper>

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "type-detect": "1.0.0"
   },
   "dependencies": {
+    "@brightspace-ui-labs/multi-select": "^3",
     "@polymer/polymer": "^3.0.0",
     "d2l-alert": "BrightspaceUI/alert#semver:^4",
     "d2l-button": "BrightspaceUI/button#semver:^5",
@@ -51,7 +52,6 @@
     "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
-    "d2l-multi-select": "BrightspaceUI/multi-select#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui#semver:^2",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "description": "",
   "homepage": "https://github.com/Brightspace/d2l-activity-alignments",
   "name": "d2l-activity-alignments",
-  "version": "1.4.25",
+  "version": "1.4.27",
   "main": "index.js",
   "scripts": {
     "lang:build": "lang-build -ec langtools/config.json",

--- a/test/d2l-activity-alignment-tags.html
+++ b/test/d2l-activity-alignment-tags.html
@@ -63,8 +63,8 @@ suite('d2l-alignment', function() {
 				var tagList, selectList, listItems;
 				var tagsLoaded = (
 					(tagList = element.$$('d2l-activity-alignment-tag-list')) &&
-					(selectList = tagList.$$('d2l-multi-select-list')) &&
-					(listItems = selectList.querySelectorAll('d2l-multi-select-list-item')) &&
+					(selectList = tagList.$$('d2l-labs-multi-select-list')) &&
+					(listItems = selectList.querySelectorAll('d2l-labs-multi-select-list-item')) &&
 					listItems.length >= 2
 				);
 


### PR DESCRIPTION
I just migrated `multi-select` over to the `BrightspaceUILabs` organization in order to better reflect its current state. This also changed the element/event names to `<d2l-labs-*>` and increased the major version number.

This adopts the new version, which will make it easier in the future to pick up updates.