### PR TITLE
use NPM reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "description": "",
   "homepage": "https://github.com/Brightspace/d2l-activity-alignments",
   "name": "d2l-activity-alignments",
-  "version": "1.4.27",
+  "version": "1.4.28",
   "main": "index.js",
   "scripts": {
     "lang:build": "lang-build -ec langtools/config.json",
@@ -47,7 +47,7 @@
     "d2l-button": "BrightspaceUI/button#semver:^5",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-fetch-siren-entity-behavior": "Brightspace/d2l-fetch-siren-entity-behavior.git#semver:^6",
-    "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",
+    "d2l-hypermedia-constants": "^6",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",


### PR DESCRIPTION
**DO NOT MERGE YET**

I'm queuing up this change across 9 different repos that get pulled into BSI, switching them all to use the NPM reference for `d2l-hypermedia-constants`. Once they're all approved, I'm merge, release & update them all at once.