### PR TITLE
Fix alignments refresh on deferred delete

### DIFF
--- a/d2l-activity-alignment-tag-list.js
+++ b/d2l-activity-alignment-tag-list.js
@@ -136,6 +136,7 @@ class ActivityAlignmentTagList extends mixinBehaviors([
 		if (!entity) return [];
 
 		if (this.deferredSave) {
+			this._alignmentMap = {};
 			this._intentMap = {};
 			this._outcomeMap = {};
 		}


### PR DESCRIPTION
Problem: If an alignment was previously in the list and then gets removed and re-added, removing it a second time via the 'X' will not refresh the UI. The alignment is correctly removed from the state.

After each edit, the intent and outcome maps are reset so we can track new entities being loaded (see previous PR #125). On the first delete of a given alignment A, the state is a new one and the entity is refetched causing the necessary updates. When returning to a previous state by re-adding that alignment, that version of the entity is already in the entity store so it doesn't refetch. The outcome and intent maps are reset to be empty though, which means that the length check [here](https://github.com/Brightspace/d2l-activity-alignments/compare/efurniss/fix_deferred_delete_refresh?expand=1#diff-4ea59b27f38966d0379b020fde46ddf6L163) will always fail.

Clearing the alignments map as well ensures a refresh in this scenario, since it will change on delete as well. Normally the alignments map is just a ever-growing list of every alignment entity that has ever been loaded, so returning to a previous state will not update this map if it is loading known entities. Clearing this map as well will cause it to trigger the required updates when the entity changes.