### PR TITLE
Support embedded alignment entities

### DIFF
--- a/d2l-activity-alignment-tag-list.js
+++ b/d2l-activity-alignment-tag-list.js
@@ -135,13 +135,12 @@ class ActivityAlignmentTagList extends mixinBehaviors([
 
 		if (!entity) return [];
 
-		if (this.deferredSave) {
-			this._alignmentMap = {};
-			this._intentMap = {};
-			this._outcomeMap = {};
+		const alignmentEntities = entity.getSubEntitiesByClass('alignment');
+
+		if (alignmentEntities.some(alignment => alignment.hasLinkByRel && alignment.hasLinkByRel('self'))) {
+			return alignmentEntities.map(alignment => alignment.getLinkByRel('self').href);
 		}
 
-		const alignmentEntities = entity.getSubEntitiesByClass('alignment');
 		return alignmentEntities.map(alignment => alignment.href);
 	}
 
@@ -158,14 +157,6 @@ class ActivityAlignmentTagList extends mixinBehaviors([
 	}
 
 	_getAlignmentToOutcomeMap(alignmentHrefs, alignmentMap, intentMap, outcomeMap, hideIndirectAlignments) {
-		if (this.entity && this.deferredSave) {
-			const count = this.entity.getSubEntitiesByClass('alignment').length;
-
-			if (Object.keys(outcomeMap).length !== count || Object.keys(intentMap).length !== count) {
-				return this._mappings;
-			}
-		}
-
 		const mappings = [];
 		alignmentHrefs.forEach(alignmentHref => {
 			const alignment = alignmentMap[alignmentHref];


### PR DESCRIPTION
Added support for embedded entities by checking the entity format when trying to access the link.

With this new embedded entity loading pattern, the changes I had previously made to avoid flicker on load are no longer required and actually break the rendering behavior, so they have been reverted.

Related LMS PR for embedding the alignment entities: https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/13568/overview

https://trello.com/c/rvokUyvv/221-cannot-use-outcomes-w-lots-of-course-outcomes