### PR TITLE
Add check for actorActivityUsage rel in Activities API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11-browsers
+      - image: circleci/node:10-browsers
 
     steps:
       - checkout

--- a/d2l-activity-alignments.js
+++ b/d2l-activity-alignments.js
@@ -35,14 +35,14 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-activity-alignments
 			}
 		</style>
 		<div class="d2l-activity-alignments-main">
-			<template is="dom-if" if="[[_isUserActivityUsage(entity)]]">
+			<template is="dom-if" if="[[_isUserOrActorActivityUsage(entity)]]">
 				<d2l-user-alignment-list href="[[_getAlignments(entity)]]" token="[[token]]" read-only$="[[readOnly]]">
 					<slot name="outcomes-title" slot="outcomes-title"></slot>
 					<slot name="show-select-outcomes" slot="show-select-outcomes"></slot>
 					<slot name="describe-aligned-outcomes" slot="describe-aligned-outcomes"></slot>
 				</d2l-alignment-list>
 			</template>
-			<template is="dom-if" if="[[!_isUserActivityUsage(entity)]]">
+			<template is="dom-if" if="[[!_isUserOrActorActivityUsage(entity)]]">
 				<d2l-alignment-list href="[[_getAlignments(entity)]]" token="[[token]]" read-only$="[[readOnly]]" header-title="[[headerTitle]]">
 					<slot name="outcomes-title" slot="outcomes-title"></slot>
 					<slot name="show-select-outcomes" slot="show-select-outcomes"></slot>
@@ -102,11 +102,12 @@ Polymer({
 		return entity && entity.hasLinkByRel(Rels.Alignments.alignments) && entity.getLinkByRel(Rels.Alignments.alignments).href;
 	},
 
-	_isUserActivityUsage: function(entity) {
+	_isUserOrActorActivityUsage: function(entity) {
 		if (!entity) return undefined;
 		const selfLink = entity.getLinkByRel('self');
 		if (!selfLink) return undefined;
-		return selfLink.rel.some(rel => rel === Rels.Activities.userActivityUsage);
+		return selfLink.rel.some(rel => (rel === Rels.Activities.userActivityUsage ||
+			rel === Rels.Activities.actorActivityUsage));
 	}
 
 });

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:lint:wc": "polymer lint",
     "serve": "FOR /F \"tokens=*\" %F IN ('hostname') DO polymer serve --hostname %F.desire2learn.d2l",
     "serve:local": "polymer serve",
-    "testcafe:chrome": "testcafe \"saucelabs:Chrome@73.0:Windows 10\" TestCafe/LOA_on_Outcomes.js --app \"polymer serve\"",
+    "testcafe:chrome": "testcafe \"saucelabs:Chrome@85.0:Windows 10\" TestCafe/LOA_on_Outcomes.js --app \"polymer serve\"",
     "testcafe:local:chrome": "testcafe chrome TestCafe/LOA_on_Outcomes.js --app \"polymer serve\""
   },
   "author": "D2L Corporation",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "eslint-config-brightspace": "^0.4.1",
     "eslint-plugin-html": "^5.0.3",
     "polymer-cli": "^1.9.6",
-    "testcafe": "^1.1.3",
-    "testcafe-browser-provider-saucelabs": "^1.7.0",
+    "testcafe": "^1.9.3",
+    "testcafe-browser-provider-saucelabs": "^1.8.0",
     "wct-browser-legacy": "^1.0.1",
     "whatwg-fetch": "^2.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "description": "",
   "homepage": "https://github.com/Brightspace/d2l-activity-alignments",
   "name": "d2l-activity-alignments",
-  "version": "2.0.17",
+  "version": "2.0.20",
   "main": "index.js",
   "scripts": {
     "lang:build": "lang-build -ec langtools/config.json",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:lint:wc": "polymer lint",
     "serve": "FOR /F \"tokens=*\" %F IN ('hostname') DO polymer serve --hostname %F.desire2learn.d2l",
     "serve:local": "polymer serve",
-    "testcafe:chrome": "testcafe \"saucelabs:Chrome@85.0:Windows 10\" TestCafe/LOA_on_Outcomes.js --app \"polymer serve\"",
+    "testcafe:chrome": "testcafe \"saucelabs:Chrome@73.0:Windows 10\" TestCafe/LOA_on_Outcomes.js --app \"polymer serve\"",
     "testcafe:local:chrome": "testcafe chrome TestCafe/LOA_on_Outcomes.js --app \"polymer serve\""
   },
   "author": "D2L Corporation",
@@ -29,8 +29,8 @@
     "eslint-config-brightspace": "^0.4.1",
     "eslint-plugin-html": "^5.0.3",
     "polymer-cli": "^1.9.6",
-    "testcafe": "^1.9.3",
-    "testcafe-browser-provider-saucelabs": "^1.8.0",
+    "testcafe": "^1.1.3",
+    "testcafe-browser-provider-saucelabs": "^1.7.0",
     "wct-browser-legacy": "^1.0.1",
     "whatwg-fetch": "^2.0.4"
   },

--- a/test/d2l-activity-alignment-tags.html
+++ b/test/d2l-activity-alignment-tags.html
@@ -74,7 +74,7 @@ suite('d2l-alignment', function() {
 				}
 
 				assert.equal(
-					listItems[0].$.tag.querySelector('div').innerText,
+					listItems[0].$.tag.querySelector('.d2l-labs-multi-select-list-item-text').innerText,
 					'Interpret words and phrases as they are ...'
 				);
 				assert.equal(
@@ -83,7 +83,7 @@ suite('d2l-alignment', function() {
 				);
 
 				assert.equal(
-					listItems[1].$.tag.querySelector('div').innerText,
+					listItems[1].$.tag.querySelector('.d2l-labs-multi-select-list-item-text').innerText,
 					'L.K.41'
 				);
 				assert.equal(


### PR DESCRIPTION
Check for the actor activity usage rel constant in addition to the user activity usage because of API addition of "actors"

I think this will be waiting on a release from the constants repo, but the actorActivityUsage rel is merged:
https://github.com/Brightspace/d2l-hypermedia-constants/commit/3785de80260bba732807c83812186dbd8d429183