### PR TITLE
Bump d2l-outcomes-level-of-achievement to latest version (v3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "description": "",
   "homepage": "https://github.com/Brightspace/d2l-activity-alignments",
   "name": "d2l-activity-alignments",
-  "version": "2.0.21",
+  "version": "2.0.22",
   "main": "index.js",
   "scripts": {
     "lang:build": "lang-build -ec langtools/config.json",
@@ -55,7 +55,7 @@
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
-    "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui#semver:^2",
+    "d2l-outcomes-level-of-achievements": "Brightspace/outcomes-level-of-achievement-ui#semver:^3",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1",
     "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",


### PR DESCRIPTION
Bump the major version of `d2l-outcomes-level-of-achievement` to Major Version 3
* This change only affects the `d2l-alignment` component, and should not have any breaking changes
* This and `consistent-evaluation` should be the only BSI components that use the `d2l-outcomes-level-of-achievement` component