### PR TITLE
Remove extra margin on top of list

### DIFF
--- a/d2l-alignment-list.js
+++ b/d2l-alignment-list.js
@@ -36,7 +36,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-alignment-list">
 				/* The standard button box-shadow width */
 				--d2l-alignment-list-overflow-margin: 4px;
 			}
-			
+
 			.d2l-alignment-list-content {
 				display: flex;
 				flex-direction: column;
@@ -67,7 +67,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-alignment-list">
 				padding: 0;
 				overflow: auto;
 				margin: 0;
-				margin-top: 0.9rem;
+				margin-top: -1.3rem;
 			}
 
 			li {
@@ -100,7 +100,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-alignment-list">
 			d2l-alert {
 				margin-top: 0.5rem;
 			}
-			
+
 			.alignment-list-header {
 				@apply --d2l-heading-3;
 				margin-bottom: 0;

--- a/d2l-user-alignment-list.js
+++ b/d2l-user-alignment-list.js
@@ -65,7 +65,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-user-alignment-list
 				padding: 0;
 				overflow: auto;
 				margin: 0;
-				margin-top: 0.9rem;
+				margin-top: -1.3rem;
 			}
 
 			li {


### PR DESCRIPTION
[US119642](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fuserstory%2F417035270204)

Remove extra margin at top of outcomes list to better align with `consistent-evaluation` header.
Before:
![image](https://user-images.githubusercontent.com/32204301/110014246-904ea300-7cf0-11eb-8238-0f1017e26466.png)

After:
![image](https://user-images.githubusercontent.com/32204301/110014182-7e6d0000-7cf0-11eb-9efd-72e33dbb9c25.png)
