### PR TITLE
Add back `en`

### DIFF
--- a/langtools/config.json
+++ b/langtools/config.json
@@ -8,6 +8,7 @@
     "cy",
     "da",
     "de",
+    "en",
     "es",
     "es-es",
     "fr",


### PR DESCRIPTION
Accidently removed with `fr-ON` work.