### PR TITLE
[BfP] Standards not appearing in assignments

### DIFF
--- a/d2l-user-alignment-list.js
+++ b/d2l-user-alignment-list.js
@@ -65,7 +65,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-user-alignment-list
 				padding: 0;
 				overflow: auto;
 				margin: 0;
-				margin-top: -1.3rem;
+				margin-top: -1.1rem;
 			}
 
 			li {


### PR DESCRIPTION
There is a top margin issue when the first item in the list is a one sentence description.

![image](https://user-images.githubusercontent.com/83982257/121091113-1d513e80-c7af-11eb-87a8-54df84dec979.png)

This behavior is similar at different places and should look like this after the fix.

![image](https://user-images.githubusercontent.com/83982257/121091212-470a6580-c7af-11eb-8c21-b118d2c7208b.png)


https://rally1.rallydev.com/#/378960033600d/custom/382879628416?detail=%2Fdefect%2F605804569524&fdp=true?fdp=true